### PR TITLE
Fixed msn login fail in e3.msn when password has more than 16 chars

### DIFF
--- a/emesene/e3/msn/Session.py
+++ b/emesene/e3/msn/Session.py
@@ -26,6 +26,9 @@ class Session(e3.Session):
         worker = Worker('emesene2', self, proxy, use_http)
         worker.start()
 
+        #msn password must have 16 chars max.
+        password=password[:16]
+        #------------------------------------
         self.account = e3.Account(account, password, status, host)
 
         self.add_action(e3.Action.ACTION_LOGIN, (account, password, status,


### PR DESCRIPTION
Modfied Session.py in e3/base folder. The password now is cutted to 16 characters -the msn maximun- before login.
