### PR TITLE
MarkupParser just parse message body only

### DIFF
--- a/emesene/gui/base/MarkupParser.py
+++ b/emesene/gui/base/MarkupParser.py
@@ -2,6 +2,7 @@
 # convert it into a restricted subset of xhtml
 import os
 import xml.sax.saxutils
+import re
 
 import gui
 
@@ -27,7 +28,11 @@ def parse_emotes(message, cedict={}):
     '''parser the emotes in a message, return a string with img tags
     for the emotes acording to the theme'''
 
-    chunks = [message]
+    # Get the message body to parse emotes
+    p = re.compile('<span.*?>(.*)</span>', re.DOTALL)
+    plain_text = p.search(message).group(1)
+
+    chunks = [plain_text]
     shortcuts = gui.Theme.EMOTES.keys()
     if cedict is not None:
         shortcuts.extend(cedict.keys())
@@ -57,7 +62,8 @@ def parse_emotes(message, cedict={}):
 
         chunks = temp
 
-    return ''.join(chunks)
+    # return the markup with plan text
+    return message.replace(plain_text, ''.join(chunks))
 
 
 def replace_emotes(msgtext, cedict={}, cedir=None):

--- a/emesene/gui/gtkui/RichWidget.py
+++ b/emesene/gui/gtkui/RichWidget.py
@@ -1,4 +1,5 @@
 import gtk
+import xml.parsers.expat
 
 import e3
 import logging


### PR DESCRIPTION
Fix the parse_emotes() parse attribute even in <span> attribute.
e.g.
    <span style="color: #000080;font-family: 華康宗楷體W7(P);">MESSAGE BODY IS HERE</span>

The "(P)" will be parsed to emote.
