### PR TITLE
Fixed login with more than 16 chars on papylib

### DIFF
--- a/emesene/e3/papylib/Session.py
+++ b/emesene/e3/papylib/Session.py
@@ -49,6 +49,9 @@ class Session(e3.Session):
         worker = Worker('emesene2', self, proxy, use_http)
         worker.start()
 
+        #msn password must have 16 chars max.
+        password=password[:16]
+        #------------------------------------
         self.account = e3.Account(account, password, status, host)
 
         self.add_action(e3.Action.ACTION_LOGIN, (account, password, status,


### PR DESCRIPTION
Added:
        #msn password must have 16 chars max.
        password=password[:16]
        #------------------------------------
to Session.py in papylib.
