### PR TITLE
Get the regex to recognise more urls

### DIFF
--- a/emesene/gui/base/MarkupParser.py
+++ b/emesene/gui/base/MarkupParser.py
@@ -17,7 +17,7 @@ dic_inv = {
     '&apos;'    :'\''
 }
 
-URL_REGEX_STR = 'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+URL_REGEX_STR = '(http[s]?://|www.)(?:[a-zA-Z]|[0-9]|[$\-_@.&+#/]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
 URL_REGEX = re.compile(URL_REGEX_STR)
 
 def escape(string_):
@@ -132,8 +132,10 @@ def get_custom_emotes(message, cedict={}):
 
 def replace_urls(match):
     '''function to be called on each url match'''
-    url = match.group()
-    return '<a href="%s">%s</a>' % (url, url)
+    hurl = url = match.group()
+    if url[:4] == 'www.':
+        hurl = 'http://' + url
+    return '<a href="%s">%s</a>' % (hurl, url)
 
 def urlify(strng):
     '''replace urls by an html link'''


### PR DESCRIPTION
The following links now work:

http://en.wikipedia.org/wiki/Emesene#Emesene2

https://en.wikipedia.org/wiki/Emesene#Emesene2

www.wikipedia.org/wiki/Emesene#Emesene2

http://en.wikipedia.org/wiki/Emesene

https://en.wikipedia.org/wiki/Emesene

As far as they exist anyway... Previously only 

http://en.wikipedia.org/wiki/Emesene

https://en.wikipedia.org/wiki/Emesene

worked and if they were in the same message, they would be one big link.

The last part is needed, because emesene opens the www links in the chat window itself as AdiumMessageStyle objects. So I just put the http:// in front. I have no idea if this is the good way to fix it, but at least I know how to make a pull request now :P
