### PR TITLE
Try to fix Non-English word copy error

### DIFF
--- a/emesene/gui/gtkui/TextBox.py
+++ b/emesene/gui/gtkui/TextBox.py
@@ -132,7 +132,7 @@ class TextBox(gtk.ScrolledWindow):
             text = self._replace_emo_with_shortcut()
 
             # replace clipboard content
-            gtk.clipboard_get().set_text(text, len(text))
+            gtk.clipboard_get().set_text(text, len(text.encode('utf8')))
             gtk.clipboard_get().store()
 
     def _get_text(self):


### PR DESCRIPTION
When we try to copy a chinese words (ex:'台灣臭豆腐') and it shows:
"Error converting from UTF-8 to ASCII: Partial character sequence at end
of input". Due to pass the wrong length to clipboard set_text() func.
It will cause g_utf8_validate() failed.
http://gtkplus-p2.0.sourcearchive.com/documentation/2.17.3/gdkselection-x11_8c-source.html
http://developer.gnome.org/glib/unstable/glib-Unicode-Manipulation.html#g-utf8-validate

REPRODUCE:
1.paste the word "台灣臭豆腐"
2.Ctrl + c, copy it
3.You will get error.

The root cause is, the len() pass 5 into set_text().
The correct length is 15.

I don't know if a good idea that we hard code here.
Please kindly help to check.
