### PR TITLE
Fixes on issue 634

### DIFF
--- a/emesene/e3/base/ContactManager.py
+++ b/emesene/e3/base/ContactManager.py
@@ -206,19 +206,3 @@ class ContactManager(object):
             if contact.status != status.OFFLINE])
 
         return (online, total)
-
-    def is_reverse(self, account):
-        '''return True if the account is on self.reverse; otherwise, False'''
-        return account in self.reverse
-
-    def get_blocked_list(self, contacts=None):
-        '''return a list of all blocked contacts'''
-        contacts = contacts or (self.contacts.values() + self.reverse.values())
-
-        return [contact for contact in contacts if contact.blocked]
-
-    def get_allowed_list(self, contacts=None):
-        '''return a list of all allowed contacts'''
-        contacts = contacts or (self.contacts.values() + self.reverse.values())
-
-        return [contact for contact in contacts if not contact.blocked]

--- a/emesene/e3/papylib/Session.py
+++ b/emesene/e3/papylib/Session.py
@@ -22,6 +22,7 @@ import e3
 from Worker import Worker
 
 import extension
+from papyon.profile import Membership
 
 AUTHOR_LIST = ['Riccardo (C10uD)', 'Orfeo (Otacon)', 'Stefano (cando)']
 
@@ -94,3 +95,52 @@ class Session(e3.Session):
     def get_profile(self):
         return self.__worker.profile.profile
 
+    # methods for the privacy tab
+    def get_blocked_contacts(self):
+        '''return a list containing the contacts in the address book with the
+        BLOCK flag set'''
+        contacts = self.__worker.address_book.contacts
+        return [c.account for c in contacts if (Membership.BLOCK & c.memberships) and \
+                ((Membership.FORWARD & c.memberships) or (Membership.REVERSE & c.memberships))]
+    
+    def get_allowed_contacts(self):
+        '''return a list containing the contacts in the address book with the
+        ALLOW flag set'''
+        contacts = self.__worker.address_book.contacts
+        return [c.account for c in contacts if (Membership.ALLOW & c.memberships) and \
+                ((Membership.REVERSE & c.memberships) or (Membership.FORWARD & c.memberships))]
+
+    def is_only_reverse(self, account):
+        '''return True if the contact has set the REVERSE flag and not the
+        FORWARD flag; otherwise False.
+        This means, contacts that are not in your contact list but they do have
+        you'''
+        contacts = self.__worker.address_book.contacts.search_by('account', account)
+
+        if len(contacts) == 0:
+            return False
+
+        return (Membership.REVERSE & contacts[0].memberships) and \
+                not (Membership.FORWARD & contacts[0].memberships)
+        
+    def is_only_forward(self, account):
+        '''return True if the contact has set the FORWARD flag and not the
+        REVERSE flag; otherwise False.
+        This means, contacts that are in your contact list but they don't have
+        you'''
+        contacts = self.__worker.address_book.contacts.search_by('account', account)
+
+        if len(contacts) == 0:
+            return False
+        
+        return (Membership.FORWARD & contacts[0].memberships) and \
+                not (Membership.REVERSE & contacts[0].memberships)
+
+    def is_forward(self, account):
+        '''return True if the contact has set the FORWARD flag; otherwise False'''
+        contacts = self.__worker.address_book.contacts.search_by('account', account)
+
+        if len(contacts) == 0:
+            return False
+            
+        return (Membership.FORWARD & contacts[0].memberships)

--- a/emesene/gui/gtkui/Preferences.py
+++ b/emesene/gui/gtkui/Preferences.py
@@ -142,7 +142,7 @@ class Preferences(gtk.Window):
         self.interface.remove_subscriptions()
         self.sound.remove_subscriptions()
         self.theme.remove_subscriptions()
-        if getattr(self, 'msn_papylib'):
+        if hasattr(self, 'msn_papylib'):
             self.msn_papylib.privacy.remove_subscriptions()
 
     def remove_from_list(self, icon, text, page):

--- a/emesene/gui/gtkui/Preferences.py
+++ b/emesene/gui/gtkui/Preferences.py
@@ -142,6 +142,8 @@ class Preferences(gtk.Window):
         self.interface.remove_subscriptions()
         self.sound.remove_subscriptions()
         self.theme.remove_subscriptions()
+        if getattr(self, 'msn_papylib'):
+            self.msn_papylib.privacy.remove_subscriptions()
 
     def remove_from_list(self, icon, text, page):
 
@@ -997,7 +999,8 @@ class MSNPapylib(BaseTable):
         self.attach(align_prin, 0, 1, 0, 1)
 
         # lists to manage contacts
-        vbox.pack_start(PrivacySettings(self.session), True, True)
+        self.privacy = PrivacySettings(self.session)
+        vbox.pack_start(self.privacy, True, True)
 
         self.show_all()
 
@@ -1113,6 +1116,13 @@ class PrivacySettings(gtk.VBox):
         self.session.signals.contact_block_succeed.subscribe(self._update_lists)
         self.session.signals.contact_unblock_succeed.subscribe(self._update_lists)
         self.session.signals.contact_added_you.subscribe(self._update_lists)
+
+    def remove_subscriptions(self):
+        self.session.signals.contact_add_succeed.unsubscribe(self._update_lists)
+        self.session.signals.contact_remove_succeed.unsubscribe(self._update_lists)
+        self.session.signals.contact_block_succeed.unsubscribe(self._update_lists)
+        self.session.signals.contact_unblock_succeed.unsubscribe(self._update_lists)
+        self.session.signals.contact_added_you.unsubscribe(self._update_lists)
 
     def _update_lists(self, contact=None):
         ''' clears all the values of the models and fill them again '''


### PR DESCRIPTION
- now the privacy widget is subscribed to some signals in order to update the lists when a contact is modified outside this widget.
- added a few methods in the papylib session to search the contacts with a determined set of flags (block/unblock/reverse/forward). Thus, the methods added to the base.ContactManager class in the
  last commit, have been deleted (are no longer required).
