### PR TITLE
emesene conflicts with empathy because it depends on farsight and in the new ubuntu there's none but another similar lib

### DIFF
--- a/emesene/e3/papylib/PapyConference.py
+++ b/emesene/e3/papylib/PapyConference.py
@@ -24,7 +24,11 @@ from papyon.event.media import *
 import pygst
 pygst.require('0.10')
 
-import farsight
+try:
+    import farstream as farsight
+except ImportError: # Hello older systems
+    import farsight
+
 import gobject
 import gst
 import logging


### PR DESCRIPTION
fixes LP: #956422 and should allow debian packagers to drop the farsight2 dep in favour of the new farstream library (which doesn't fix our problems with codecs, but anyway)
