### PR TITLE
gtkui.TextBox: Check on_key_press_event for Input Method. Close #1236.

### DIFF
--- a/emesene/gui/gtkui/TextBox.py
+++ b/emesene/gui/gtkui/TextBox.py
@@ -196,7 +196,8 @@ class InputView(gtk.TextView):
         if event.keyval in [gtk.keysyms.Return, gtk.keysyms.KP_Enter] and \
             not event.state & gtk.gdk.SHIFT_MASK:
 
-            self.emit('message-send')
+            if not self.im_context_filter_keypress(event):
+                self.emit('message-send')
             return True
         return False
 


### PR DESCRIPTION
Check if the key event is handled by input method first. If the event is processed by IM, do not try to send message.
