### PR TITLE
gtkui.TextBox: Check on_key_press_event for Input Method before Cycle history.

### DIFF
--- a/emesene/gui/gtkui/TextBox.py
+++ b/emesene/gui/gtkui/TextBox.py
@@ -268,13 +268,16 @@ class InputText(TextBox):
                  event.keyval == gtk.keysyms.p or \
                     event.keyval == gtk.keysyms.Up:
 
-            self.on_cycle_history()
-
+            if not self._textbox.im_context_filter_keypress(event):
+                self.on_cycle_history()
+            return True
         elif event.state == gtk.gdk.CONTROL_MASK and \
                 event.keyval == gtk.keysyms.n or \
                     event.keyval == gtk.keysyms.Down:
 
-            self.on_cycle_history(1)
+            if not self._textbox.im_context_filter_keypress(event):
+                self.on_cycle_history(1)
+            return True
         else:
             if self.typing_timeout is None:
                 self.send_typing_notification()


### PR DESCRIPTION
Check if the key event is handled by input method first. If the event is processed by IM, do not try to use cycle history.
