### PR TITLE
gtkui.TextBox: Correct format of Control Mask in Cycle history.

### DIFF
--- a/emesene/gui/gtkui/TextBox.py
+++ b/emesene/gui/gtkui/TextBox.py
@@ -264,16 +264,16 @@ class InputText(TextBox):
         self.changed = True
         self.apply_tag()
 
-        if event.state == gtk.gdk.CONTROL_MASK and \
-                 event.keyval == gtk.keysyms.p or \
-                    event.keyval == gtk.keysyms.Up:
+        if ( event.state & gtk.gdk.CONTROL_MASK ) and \
+                 ( event.keyval == gtk.keysyms.p or \
+                    event.keyval == gtk.keysyms.Up ):
 
             if not self._textbox.im_context_filter_keypress(event):
                 self.on_cycle_history()
             return True
-        elif event.state == gtk.gdk.CONTROL_MASK and \
-                event.keyval == gtk.keysyms.n or \
-                    event.keyval == gtk.keysyms.Down:
+        elif ( event.state == gtk.gdk.CONTROL_MASK ) and \
+                ( event.keyval == gtk.keysyms.n or \
+                    event.keyval == gtk.keysyms.Down ):
 
             if not self._textbox.im_context_filter_keypress(event):
                 self.on_cycle_history(1)


### PR DESCRIPTION
Correct the Control Mask format and the original combined key based on commit abac7dc5893a7a52a2e7debe94ab5e5a5b957a7c.
