### PR TITLE
gtkui.TextBox: Correct format of Control Mask in Cycle history for ctrl+n/down.

### DIFF
--- a/emesene/gui/gtkui/TextBox.py
+++ b/emesene/gui/gtkui/TextBox.py
@@ -271,7 +271,7 @@ class InputText(TextBox):
             if not self._textbox.im_context_filter_keypress(event):
                 self.on_cycle_history()
             return True
-        elif ( event.state == gtk.gdk.CONTROL_MASK ) and \
+        elif ( event.state & gtk.gdk.CONTROL_MASK ) and \
                 ( event.keyval == gtk.keysyms.n or \
                     event.keyval == gtk.keysyms.Down ):
 

--- a/emesene/gui/gtkui/Window.py
+++ b/emesene/gui/gtkui/Window.py
@@ -216,7 +216,10 @@ class Window(gtk.Window):
         '''call the cb_on_close callback, if the callback return True
         then dont close the window'''
         self.save_dimensions()
-        return self.cb_on_close(self.content_main)
+        if self.content_conv is not None:
+            return self.cb_on_close(self.content_conv)
+        else:
+            return self.cb_on_close(self.content_main)
 
     def _on_last_tab_close(self):
         '''do the action when the last tab is closed on a conversation window


### PR DESCRIPTION
Add missing logic for this hot key. Sorry for inconvenient.
