### PR TITLE
gui.gtkui.Window: Hide conversation window when closing last tab in non-single-window mode. Closes #1286.

### DIFF
--- a/emesene/gui/gtkui/Window.py
+++ b/emesene/gui/gtkui/Window.py
@@ -253,6 +253,8 @@ class Window(gtk.Window):
         '''
         self.cb_on_close_conv(self.content_conv)
         self.content_conv = None
+        if not self.content_main:
+            self.hide()
 
     def hide(self):
         '''override the method to remember the position


### PR DESCRIPTION
The conversation window should be hide/closed in non-single-window mode.
