### PR TITLE
implement disconnect other endpoints, minor code cleanup

### DIFF
--- a/emesene/e3/base/Worker.py
+++ b/emesene/e3/base/Worker.py
@@ -92,7 +92,7 @@ ACTIONS = (\
  'call cancel', 'call reject',
  'p2p invite'       , 'p2p accept',
  'p2p cancel'       , 'media send', # media send if got Wink and audio clips
- 'send oim')
+ 'send oim', 'disconnect other endpoints')
 
 Event.set_constants(EVENTS)
 Action.set_constants(ACTIONS)
@@ -167,6 +167,8 @@ class Worker(threading.Thread):
         dah[Action.ACTION_CALL_ACCEPT] = self._handle_action_call_accept
         dah[Action.ACTION_CALL_REJECT] = self._handle_action_call_reject
         dah[Action.ACTION_CALL_CANCEL] = self._handle_action_call_cancel
+        # papylib specific
+        dah[Action.ACTION_DISCONNECT_OTHER_ENDPOINTS] = self._handle_action_disconnect_other_endpoints
 
         self.action_handlers = dah
 

--- a/emesene/e3/papylib/PapyEvents.py
+++ b/emesene/e3/papylib/PapyEvents.py
@@ -26,6 +26,8 @@ import papyon.gnet.errors
 import logging
 log = logging.getLogger('papylib.Events')
 
+PROFILE_URL = "http://profile.live.com/details/Edit/Pic"
+
 class ClientEvents(papyon.event.ClientEventInterface):
     def on_client_state_changed(self, state):
         if state == papyon.event.ClientState.CLOSED:
@@ -78,11 +80,13 @@ class ClientEvents(papyon.event.ClientEventInterface):
             if isinstance(error, papyon.gnet.errors.HTTPError) and \
                error.response and error.response.status and \
                error.response.status == 404:
-                self._client.session.add_event(Event.EVENT_BROKEN_PROFILE)
+                self._client.session.add_event(Event.EVENT_BROKEN_PROFILE,
+                                               PROFILE_URL)
                 return
             try:
                 if error._fault == "ItemDoesNotExist":
-                    self._client.session.add_event(Event.EVENT_BROKEN_PROFILE)
+                    self._client.session.add_event(Event.EVENT_BROKEN_PROFILE,
+                                                   PROFILE_URL)
             except AttributeError:
                 log.error("Client got an error: %s %s" % (error_type, error))
         elif error_type == papyon.event.ClientErrorType.ADDRESSBOOK:#TODO

--- a/emesene/e3/papylib/Session.py
+++ b/emesene/e3/papylib/Session.py
@@ -52,6 +52,10 @@ class Session(e3.Session):
         # keepalive conversations...or not
         b_keepalive = self.config.get_or_set("b_papylib_keepalive", False)
         self.__worker.keepalive_conversations = b_keepalive
+        # disconnect other endpoints...or not
+        b_dc_ep = self.config.get_or_set("b_papylib_disconnect_ep", False)
+        if b_dc_ep:
+            self.add_action(e3.Action.ACTION_DISCONNECT_OTHER_ENDPOINTS)
 
     def login(self, account, password, status, proxy, host, port, use_http=False):
         '''start the login process'''

--- a/emesene/e3/papylib/Worker.py
+++ b/emesene/e3/papylib/Worker.py
@@ -93,6 +93,8 @@ class Worker(e3.base.Worker, papyon.Client):
             self.client = papyon.Client.__init__(self, server,
                 proxies=get_proxies(), version=18)
 
+        self.profile_url = PROFILE_URL
+
         self._event_handler = ClientEvents(self)
         self._contact_handler = ContactEvent(self)
         self._invite_handler = InviteEvent(self)
@@ -1456,3 +1458,7 @@ class Worker(e3.base.Worker, papyon.Client):
 
         del self.calls[self.rcalls[c]]
         del self.rcalls[c]
+
+    def _handle_action_disconnect_other_endpoints(self):
+        self.disconnect_other_endpoints()
+

--- a/emesene/e3/papylib/papyon/papyon/client.py
+++ b/emesene/e3/papylib/papyon/papyon/client.py
@@ -284,7 +284,7 @@ class Client(EventsDispatcher):
             @param password: the password needed to authenticate to the account
             @type password: utf-8 encoded string
             """
-        if (self._state != ClientState.CLOSED):
+        if self._state != ClientState.CLOSED:
             logger.warning('login already in progress')
             return
         self.__die = False
@@ -304,6 +304,13 @@ class Client(EventsDispatcher):
         self._switchboard_manager.close()
         self._protocol.signoff()
         self.__state = ClientState.CLOSED
+
+    def disconnect_other_endpoints(self):
+        """ Disconnects other endpoints """
+        if self._state == ClientState.CLOSED:
+            return
+        self._protocol.send_user_notification("goawyplzthxbye-nomorempop",
+           self.profile.account, "", 4)
 
     ### Protected API --------------------------------------------------------
     @property

--- a/emesene/gui/base/MainWindowBase.py
+++ b/emesene/gui/base/MainWindowBase.py
@@ -59,10 +59,10 @@ class MainWindowBase(object):
     def _on_social_request(self, conn_url):
         pass
 
-    def _on_broken_profile(self):
+    def _on_broken_profile(self, profile_url):
         '''called when a person has a broken profile'''
         dialog = extension.get_default('dialog')
-        dialog.broken_profile(self.session.close)
+        dialog.broken_profile(self.session.close, profile_url)
 
     def on_disconnect(self):
         '''callback called when the disconnect option is selected'''

--- a/emesene/gui/gtkui/Dialog.py
+++ b/emesene/gui/gtkui/Dialog.py
@@ -1065,7 +1065,7 @@ class Dialog(object):
         return dialog
 
     @classmethod
-    def broken_profile(cls, close_cb):
+    def broken_profile(cls, close_cb, profile_url):
         '''a dialog that asks you to fix your profile'''
         message = _('''\
 Your live profile seems to be broken,
@@ -1082,7 +1082,7 @@ Clicking Yes will close emesene.
 
 Do you want to fix your profile now?''')
         def fix_profile(button, close_cb):
-            gui.base.Desktop.open("http://profile.live.com/details/Edit/Pic")
+            gui.base.Desktop.open(profile_url)
             close_cb()
 
         window = cls.common_window(message, gtk.STOCK_DIALOG_WARNING,

--- a/emesene/gui/gtkui/Preferences.py
+++ b/emesene/gui/gtkui/Preferences.py
@@ -1269,6 +1269,11 @@ class MSNPapylib(BaseTable):
         c_keep.connect('toggled', self._on_keepalive_toggled)
         vbox.pack_start(c_keep, False, False)
 
+        c_ep = gtk.CheckButton(_("Disconnect other endpoints when logging in"))
+        c_ep.set_active(self.session.config.b_papylib_disconnect_ep)
+        c_ep.connect('toggled', self._on_ep_toggled)
+        vbox.pack_start(c_ep, False, False)
+
         l_text = gtk.Label(_('If you have problems with your nickname/message/picture '
                         'just click on this button, sign in with your account '
                         'and load a picture in your Live Profile. '
@@ -1300,9 +1305,16 @@ class MSNPapylib(BaseTable):
         worker.keepalive_conversations = widget.get_active()
         self.session.config.b_papylib_keepalive = widget.get_active()
 
+    def _on_ep_toggled(self, widget):
+        ''' enable/disable conversation's keepalives in papyon '''
+        worker = self.session.get_worker()
+        worker.disconnect_ep = widget.get_active()
+        self.session.config.b_papylib_disconnect_ep = widget.get_active()
+
     def _on_live_profile_clicked(self, arg):
         ''' called when live profile button is clicked '''
-        gui.base.Desktop.open("http://profile.live.com/details/Edit/Pic")
+        profile_url = self.session.get_worker().profile_url
+        gui.base.Desktop.open(profile_url)
 
 class Facebook(BaseTable):
     """ This panel contains some facebook specific settings """

--- a/emesene/gui/qt4ui/Dialog.py
+++ b/emesene/gui/qt4ui/Dialog.py
@@ -24,7 +24,7 @@ class Dialog(object):
     WEBSITE = ''
 
     @classmethod
-    def broken_profile(cls, close_cb):
+    def broken_profile(cls, close_cb, url):
         '''a dialog that asks you to fix your profile'''
         message = _('''\
 Your live profile seems to be broken,
@@ -40,7 +40,7 @@ To fix your profile, emesene must be closed.
 Clicking Yes will close emesene.
 
 Do you want to fix your profile now?''')
-        gui.base.Desktop.open("http://profile.live.com/details/Edit/Pic")
+        gui.base.Desktop.open(url)
 
         reply = QtGui.QMessageBox.warning(None, _("You have a broken profile"),
                                           message, QtGui.QMessageBox.Yes |

--- a/emesene/gui/qt4ui/Preferences.py
+++ b/emesene/gui/qt4ui/Preferences.py
@@ -714,4 +714,6 @@ class MSNPapylib(BaseTable):
 
     def _on_live_profile_clicked(self, arg):
         ''' called when live profile button is clicked '''
-        gui.base.Desktop.open("http://profile.live.com/details/Edit/Pic")
+        profile_url = self.session.get_worker().profile_url
+        gui.base.Desktop.open(profile_url)
+


### PR DESCRIPTION
papyon: implement endpoint disconnection (thanks kmess et. al.)
emesene: added configuration option in live messenger tab
papylib: moved profile url to papyevents/worker instead of spreading the string all around.

closes #862
