### PR TITLE
gui.gtkui.ConversationManager: Make Ctrl+W to close tab work without escape shortcut enabled. Refs #1139.

### DIFF
--- a/emesene/gui/gtkui/ConversationManager.py
+++ b/emesene/gui/gtkui/ConversationManager.py
@@ -96,11 +96,15 @@ class ConversationManager(gtk.Notebook, gui.ConversationManager):
         '''Catches events like Ctrl+W and closes current tab'''
         if not self.get_focus_child():
             return
-        if self.session.config.get_or_set('b_escape_hotkey', True):
-            index = self.get_current_page()
-            conversation = self.get_nth_page(index)
-            self.close(conversation)
-            return True
+        if (keyval == gtk.keysyms.Escape and modifier == 0 ) and \
+           not self.session.config.get_or_set('b_escape_hotkey', True):
+            return
+
+        index = self.get_current_page()
+        conversation = self.get_nth_page(index)
+        self.close(conversation)
+        
+        return True
 
     def on_key_change_tab(self, accelGroup, window, keyval, modifier):
         '''Catches alt+number and shows tab number-1  '''


### PR DESCRIPTION
First seem in commit 6780c333fc71c09665e085704a10695e53765720. If not enable escape shortcut, the ctrl+w malfunctioned.

It is strange the keyval is always 119 (gtk.keysyms.w) in my system, where the function defined is gtk.keysyms.W. The two values (W/w) can be passed into the close function so I made a check for escape to prevent any unpredictable error.
