### PR TITLE
Fix emotion selector on Lion

### DIFF
--- a/emesene/gui/gtkui/Dialog.py
+++ b/emesene/gui/gtkui/Dialog.py
@@ -581,7 +581,7 @@ class Dialog(object):
             gui.base.Desktop.open(web)
 
         def on_email_hook(dialog, mail):
-            gui.base.Desktop.open("mailto://"+mail)
+            gui.base.Desktop.open("mailto:"+mail)
 
         about = gtk.AboutDialog()
         gtk.about_dialog_set_url_hook(on_website_hook)

--- a/emesene/gui/gtkui/Dialog.py
+++ b/emesene/gui/gtkui/Dialog.py
@@ -1345,7 +1345,7 @@ class EmotesWindow(gtk.Window):
 
         #XXX: Don't set undecorated on macos lion, it crash see #1065
         import platform, sys
-        if not (sys.platform == 'darwin' and platform.release().startswith('11.3')):
+        if not (sys.platform == 'darwin' and platform.mac_ver()[0].startswith('10.7')):
             self.set_decorated(False)
         self.set_role("emotes")
         self.set_type_hint(gtk.gdk.WINDOW_TYPE_HINT_DIALOG)


### PR DESCRIPTION
Fix emotion selector on Lion, platform.release() actually returns 11.4 on latest lion not 11.3, so i switched to mac_version instead.

Also is a fix for mailto links having // before the email address.
